### PR TITLE
Add defaults outside of Rails

### DIFF
--- a/lib/configs.rb
+++ b/lib/configs.rb
@@ -16,11 +16,17 @@ module Configs
 
     # Where the wild .yml live.
     # In a Rails app, this is Rails.root.join('config')
-    attr_accessor :config_dir
+    attr_writer :config_dir
+    def config_dir
+      @config_dir ||= Pathname.new('./configs')
+    end
 
     # The name of our environment.
     # In a Rails app, this is Rails.env
-    attr_accessor :environment
+    attr_writer :environment
+    def environment
+      @environment ||= 'default'
+    end
 
     # will find (and memoize) the yml config file with this name
     #

--- a/test/configs_test.rb
+++ b/test/configs_test.rb
@@ -2,6 +2,11 @@ require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
 class ConfigsTest < Configs::TestCase
   def setup
+    @_original_config_dir = Configs.config_dir
+    @_original_environment = Configs.environment
+
+    Configs.config_dir = Pathname.new(File.dirname(__FILE__) + '/config')
+    Configs.environment = 'test'
     Configs.reload
   end
 
@@ -54,6 +59,11 @@ class ConfigsTest < Configs::TestCase
 
   should "interpolate ERB" do
     assert_equal 3, Configs[:erb][:three]
+  end
+
+  def teardown
+    Configs.config_dir = @_original_config_dir
+    Configs.environment = @_original_environment
   end
 
   protected

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -1,0 +1,8 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+
+class DefaultsTest < Configs::TestCase
+  should "have sane defaults" do
+    assert_equal Pathname.new('./configs'), Configs.config_dir
+    assert_equal 'default', Configs.environment
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,5 +10,3 @@ class Configs::TestCase < Minitest::Test
   end
 end
 
-Configs.config_dir = Pathname.new(File.dirname(__FILE__) + '/config')
-Configs.environment = 'test'


### PR DESCRIPTION
There was no default config directory or environment specified outside of Rails. I added a default config path of './configs' and a default environment called 'default'. The Rails defaults should take precedence.
