### PR TITLE
Changed the railtie to use the before_configuration callback so we ca…

### DIFF
--- a/gemfiles/activesupport3.2
+++ b/gemfiles/activesupport3.2
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 gemspec path: '../'
 
 gem 'activesupport', '~> 3.2.0'
+gem 'minitest', '~> 4.7.5'

--- a/lib/configs/railtie.rb
+++ b/lib/configs/railtie.rb
@@ -1,6 +1,6 @@
 module Configs
   class Railtie < Rails::Railtie
-    initializer 'configs.rails_settings' do
+    config.before_configuration do
       Configs.config_dir = Rails.root.join('config')
       Configs.environment = Rails.env
     end

--- a/lib/configs/version.rb
+++ b/lib/configs/version.rb
@@ -1,3 +1,3 @@
 module Configs
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/test/defaults_test.rb
+++ b/test/defaults_test.rb
@@ -1,8 +1,12 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
 class DefaultsTest < Configs::TestCase
+  def get_environment
+    ENV['RACK_ENV'] ? ENV['RACK_ENV'] : 'default' 
+  end
+
   should "have sane defaults" do
     assert_equal Pathname.new('./configs'), Configs.config_dir
-    assert_equal 'default', Configs.environment
+    assert_equal get_environment, Configs.environment
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ Bundler.require(:default, :test)
 
 require 'minitest/autorun'
 
-class Configs::TestCase < Minitest::Test
+class Configs::TestCase < Minitest::Unit::TestCase
   def self.should(name, &block) # very simple syntax
     define_method("test_should_#{name.gsub(/[ -\/]/, '_').gsub(/[^a-z0-9_]/i, '_')}", &block)
   end


### PR DESCRIPTION
# What
Changed the Configs Railtie to use the before_configuration callback.

# Why
In the current form the Railtie would load after our environment initialization files causing an exception if we tried to call Configs in our environment initialization files. ie. config/environments/development.rb. Using the before_configuration callback allows us to use Configs in our environment initialization files.
